### PR TITLE
Add authenticated encryption and migrate everything to PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,7 @@
 language: php
 
 php:
-  - 5.5
-  - 5.6
-  - 7.0
   - 7.1
-  - hhvm
 
 env:
   - COMPOSER_OPTS=""

--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,12 @@
     }
   },
   "require": {
-    "php": ">=5.5",
+    "php": ">=7.1",
     "ext-openssl": "*",
     "guzzlehttp/psr7": "~1.0",
     "psr/http-message": "~1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8.35|^5.4.0|^6.0.0",
-    "paragonie/random_compat": "^2.0"
+    "phpunit/phpunit": "^6.0"
   }
 }

--- a/src/AesDecryptingStream.php
+++ b/src/AesDecryptingStream.php
@@ -31,14 +31,9 @@ class AesDecryptingStream implements StreamInterface
      */
     private $stream;
 
-    /**
-     * @param StreamInterface $cipherText
-     * @param string $key
-     * @param CipherMethod $cipherMethod
-     */
     public function __construct(
         StreamInterface $cipherText,
-        $key,
+        string $key,
         CipherMethod $cipherMethod
     ) {
         $this->stream = $cipherText;
@@ -46,7 +41,7 @@ class AesDecryptingStream implements StreamInterface
         $this->cipherMethod = clone $cipherMethod;
     }
 
-    public function getSize()
+    public function getSize(): ?int
     {
         $plainTextSize = $this->stream->getSize();
 
@@ -61,12 +56,12 @@ class AesDecryptingStream implements StreamInterface
         return $plainTextSize;
     }
 
-    public function isWritable()
+    public function isWritable(): bool
     {
         return false;
     }
 
-    public function read($length)
+    public function read($length): string
     {
         if ($length > strlen($this->buffer)) {
             $this->buffer .= $this->decryptBlock(
@@ -80,7 +75,7 @@ class AesDecryptingStream implements StreamInterface
         return $data ? $data : '';
     }
 
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek($offset, $whence = SEEK_SET): void
     {
         if ($offset === 0 && $whence === SEEK_SET) {
             $this->buffer = '';
@@ -92,7 +87,7 @@ class AesDecryptingStream implements StreamInterface
         }
     }
 
-    private function decryptBlock($length)
+    private function decryptBlock(int $length): string
     {
         if ($this->stream->eof()) {
             return '';

--- a/src/AesEncryptingStream.php
+++ b/src/AesEncryptingStream.php
@@ -31,14 +31,9 @@ class AesEncryptingStream implements StreamInterface
      */
     private $stream;
 
-    /**
-     * @param StreamInterface $plainText
-     * @param string $key
-     * @param CipherMethod $cipherMethod
-     */
     public function __construct(
         StreamInterface $plainText,
-        $key,
+        string $key,
         CipherMethod $cipherMethod
     ) {
         $this->stream = $plainText;
@@ -46,7 +41,7 @@ class AesEncryptingStream implements StreamInterface
         $this->cipherMethod = clone $cipherMethod;
     }
 
-    public function getSize()
+    public function getSize(): ?int
     {
         $plainTextSize = $this->stream->getSize();
 
@@ -60,12 +55,12 @@ class AesEncryptingStream implements StreamInterface
         return $plainTextSize;
     }
 
-    public function isWritable()
+    public function isWritable(): bool
     {
         return false;
     }
 
-    public function read($length)
+    public function read($length): string
     {
         if ($length > strlen($this->buffer)) {
             $this->buffer .= $this->encryptBlock(
@@ -79,7 +74,7 @@ class AesEncryptingStream implements StreamInterface
         return $data ? $data : '';
     }
 
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek($offset, $whence = SEEK_SET): void
     {
         if ($whence === SEEK_CUR) {
             $offset = $this->tell() + $offset;
@@ -98,7 +93,7 @@ class AesEncryptingStream implements StreamInterface
         }
     }
 
-    private function encryptBlock($length)
+    private function encryptBlock(int $length): string
     {
         if ($this->stream->eof()) {
             return '';

--- a/src/AesGcmDecryptingStream.php
+++ b/src/AesGcmDecryptingStream.php
@@ -1,0 +1,61 @@
+<?php
+namespace Jsq\EncryptionStreams;
+
+use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\StreamDecoratorTrait;
+use Psr\Http\Message\StreamInterface;
+
+class AesGcmDecryptingStream implements StreamInterface
+{
+    use StreamDecoratorTrait;
+
+    private $aad;
+
+    private $initializationVector;
+
+    private $key;
+
+    private $keySize;
+
+    private $cipherText;
+
+    private $tag;
+
+    private $tagLength;
+
+    public function __construct(
+        StreamInterface $cipherText,
+        string $key,
+        string $initializationVector,
+        string $tag,
+        string $aad = '',
+        int $tagLength = 16,
+        int $keySize = 256
+    ) {
+        $this->cipherText = $cipherText;
+        $this->key = $key;
+        $this->initializationVector = $initializationVector;
+        $this->tag = $tag;
+        $this->aad = $aad;
+        $this->tagLength = $tagLength;
+        $this->keySize = $keySize;
+    }
+
+    public function createStream(): StreamInterface
+    {
+        return Psr7\stream_for(openssl_decrypt(
+            (string) $this->cipherText,
+            "aes-{$this->keySize}-gcm",
+            $this->key,
+            OPENSSL_RAW_DATA,
+            $this->initializationVector,
+            $this->tag,
+            $this->aad
+        ));
+    }
+
+    public function isWritable(): bool
+    {
+        return false;
+    }
+}

--- a/src/AesGcmEncryptingStream.php
+++ b/src/AesGcmEncryptingStream.php
@@ -1,0 +1,65 @@
+<?php
+namespace Jsq\EncryptionStreams;
+
+use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\StreamDecoratorTrait;
+use Psr\Http\Message\StreamInterface;
+
+class AesGcmEncryptingStream implements StreamInterface
+{
+    use StreamDecoratorTrait;
+
+    private $aad;
+
+    private $initializationVector;
+
+    private $key;
+
+    private $keySize;
+
+    private $plaintext;
+
+    private $tag = '';
+
+    private $tagLength;
+
+    public function __construct(
+        StreamInterface $plaintext,
+        string $key,
+        string $initializationVector,
+        string $aad = '',
+        int $tagLength = 16,
+        int $keySize = 256
+    ) {
+        $this->plaintext = $plaintext;
+        $this->key = $key;
+        $this->initializationVector = $initializationVector;
+        $this->aad = $aad;
+        $this->tagLength = $tagLength;
+        $this->keySize = $keySize;
+    }
+
+    public function createStream(): StreamInterface
+    {
+        return Psr7\stream_for(openssl_encrypt(
+            (string) $this->plaintext,
+            "aes-{$this->keySize}-gcm",
+            $this->key,
+            OPENSSL_RAW_DATA,
+            $this->initializationVector,
+            $this->tag,
+            $this->aad,
+            $this->tagLength
+        ));
+    }
+
+    public function getTag(): string
+    {
+        return $this->tag;
+    }
+
+    public function isWritable(): bool
+    {
+        return false;
+    }
+}

--- a/src/Base64DecodingStream.php
+++ b/src/Base64DecodingStream.php
@@ -23,12 +23,12 @@ class Base64DecodingStream implements StreamInterface
         $this->stream = $stream;
     }
 
-    public function getSize()
+    public function getSize(): ?int
     {
         return null;
     }
 
-    public function read($length)
+    public function read($length): string
     {
         $toRead = ceil($length / 3) * 4;
         $this->buffer .= base64_decode($this->stream->read($toRead));

--- a/src/Base64EncodingStream.php
+++ b/src/Base64EncodingStream.php
@@ -23,7 +23,7 @@ class Base64EncodingStream implements StreamInterface
         $this->stream = $stream;
     }
 
-    public function getSize()
+    public function getSize(): ?int
     {
         $unencodedSize = $this->stream->getSize();
         return $unencodedSize === null
@@ -31,7 +31,7 @@ class Base64EncodingStream implements StreamInterface
             : (int) ceil($unencodedSize / 3) * 4;
     }
 
-    public function read($length)
+    public function read($length): string
     {
         $toRead = ceil($length / 4) * 3;
         $this->buffer .= base64_encode($this->stream->read($toRead));

--- a/src/Cbc.php
+++ b/src/Cbc.php
@@ -23,11 +23,7 @@ class Cbc implements CipherMethod
      */
     private $keySize;
 
-    /**
-     * @param string $iv
-     * @param int $keySize
-     */
-    public function __construct($iv, $keySize = 256)
+    public function __construct(string $iv, int $keySize = 256)
     {
         $this->baseIv = $this->iv = $iv;
         $this->keySize = $keySize;
@@ -37,22 +33,22 @@ class Cbc implements CipherMethod
         }
     }
 
-    public function getOpenSslName()
+    public function getOpenSslName(): string
     {
         return "aes-{$this->keySize}-cbc";
     }
 
-    public function getCurrentIv()
+    public function getCurrentIv(): string
     {
         return $this->iv;
     }
 
-    public function requiresPadding()
+    public function requiresPadding(): bool
     {
         return true;
     }
 
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek(int $offset, int $whence = SEEK_SET): void
     {
         if ($offset === 0 && $whence === SEEK_SET) {
             $this->iv = $this->baseIv;
@@ -62,7 +58,7 @@ class Cbc implements CipherMethod
         }
     }
 
-    public function update($cipherTextBlock)
+    public function update(string $cipherTextBlock): void
     {
         $this->iv = substr($cipherTextBlock, self::BLOCK_SIZE * -1);
     }

--- a/src/CipherMethod.php
+++ b/src/CipherMethod.php
@@ -11,19 +11,19 @@ interface CipherMethod
      *
      * @return string
      */
-    public function getOpenSslName();
+    public function getOpenSslName(): string;
 
     /**
      * Returns the IV that should be used to encrypt or decrypt the next block.
      */
-    public function getCurrentIv();
+    public function getCurrentIv(): string;
 
     /**
      * Indicates whether the cipher method used with this IV requires padding
      * the final block to make sure the plaintext is evenly divisible by the
      * block size.
      */
-    public function requiresPadding();
+    public function requiresPadding(): bool;
 
     /**
      * Adjust the return of this::getCurrentIv to reflect a seek performed on
@@ -37,7 +37,7 @@ interface CipherMethod
      *                          only supports a full rewind ($offset === 0 &&
      *                          $whence === SEEK_SET)
      */
-    public function seek($offset, $whence = SEEK_SET);
+    public function seek(int $offset, int $whence = SEEK_SET): void;
 
     /**
      * Take account of the last cipher text block to adjust the return of
@@ -45,5 +45,5 @@ interface CipherMethod
      *
      * @param string $cipherTextBlock
      */
-    public function update($cipherTextBlock);
+    public function update(string $cipherTextBlock): void;
 }

--- a/src/Ctr.php
+++ b/src/Ctr.php
@@ -26,11 +26,7 @@ class Ctr implements CipherMethod
      */
     private $keySize;
 
-    /**
-     * @param string $iv
-     * @param int $keySize
-     */
-    public function __construct($iv, $keySize = 256)
+    public function __construct(string $iv, int $keySize = 256)
     {
         $this->keySize = $keySize;
         if (strlen($iv) !== openssl_cipher_iv_length($this->getOpenSslName())) {
@@ -41,22 +37,22 @@ class Ctr implements CipherMethod
         $this->resetOffset();
     }
 
-    public function getOpenSslName()
+    public function getOpenSslName(): string
     {
         return "aes-{$this->keySize}-ctr";
     }
 
-    public function getCurrentIv()
+    public function getCurrentIv(): string
     {
         return $this->calculateCurrentIv($this->iv, $this->ctrOffset);
     }
 
-    public function requiresPadding()
+    public function requiresPadding(): bool
     {
         return false;
     }
 
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek(int $offset, int $whence = SEEK_SET): void
     {
         if ($offset % self::BLOCK_SIZE !== 0) {
             throw new LogicException('CTR initialization vectors only support '
@@ -78,7 +74,7 @@ class Ctr implements CipherMethod
         }
     }
 
-    public function update($cipherTextBlock)
+    public function update(string $cipherTextBlock): void
     {
         $this->incrementOffset(strlen($cipherTextBlock) / self::BLOCK_SIZE);
     }
@@ -87,7 +83,7 @@ class Ctr implements CipherMethod
      * @param string $iv
      * @return int[]
      */
-    private function extractIvParts($iv)
+    private function extractIvParts(string $iv): array
     {
         return array_map(function ($part) {
             return unpack('nnum', $part)['num'];
@@ -99,7 +95,7 @@ class Ctr implements CipherMethod
      * @param int[] $ctrOffset
      * @return string
      */
-    private function calculateCurrentIv(array $baseIv, array $ctrOffset)
+    private function calculateCurrentIv(array $baseIv, array $ctrOffset): string
     {
         $iv = array_fill(0, 8, 0);
         $carry = 0;
@@ -114,7 +110,7 @@ class Ctr implements CipherMethod
         }, $iv));
     }
 
-    private function incrementOffset($incrementBy)
+    private function incrementOffset(int $incrementBy): void
     {
         for ($i = 7; $i >= 0; $i--) {
             $incrementedBlock = $this->ctrOffset[$i] + $incrementBy;
@@ -123,7 +119,7 @@ class Ctr implements CipherMethod
         }
     }
 
-    private function resetOffset()
+    private function resetOffset(): void
     {
         $this->ctrOffset = array_fill(0, 8, 0);
     }

--- a/src/Ecb.php
+++ b/src/Ecb.php
@@ -11,27 +11,27 @@ class Ecb implements CipherMethod
     /**
      * @param int $keySize
      */
-    public function __construct($keySize = 256)
+    public function __construct(int $keySize = 256)
     {
         $this->keySize = $keySize;
     }
 
-    public function getOpenSslName()
+    public function getOpenSslName(): string
     {
         return "aes-{$this->keySize}-ecb";
     }
 
-    public function getCurrentIv()
+    public function getCurrentIv(): string
     {
         return '';
     }
 
-    public function requiresPadding()
+    public function requiresPadding(): bool
     {
         return true;
     }
 
-    public function seek($offset, $whence = SEEK_SET) {}
+    public function seek(int $offset, int $whence = SEEK_SET): void {}
 
-    public function update($cipherTextBlock) {}
+    public function update(string $cipherTextBlock): void {}
 }

--- a/src/HashingStream.php
+++ b/src/HashingStream.php
@@ -34,17 +34,11 @@ class HashingStream implements StreamInterface
 
     private $algorithm;
 
-    /**
-     * @param StreamInterface $stream
-     * @param string|null $key
-     * @param callable|null $onComplete
-     * @param string $algorithm
-     */
     public function __construct(
         StreamInterface $stream,
-        $key = null,
-        callable $onComplete = null,
-        $algorithm = 'sha256'
+        ?string $key = null,
+        ?callable $onComplete = null,
+        string $algorithm = 'sha256'
     ){
         $this->stream = $stream;
         $this->key = $key;
@@ -57,15 +51,13 @@ class HashingStream implements StreamInterface
     /**
      * Returns the raw binary hash of the wrapped stream if it has been read.
      * Returns null otherwise.
-     *
-     * @return string|null
      */
-    public function getHash()
+    public function getHash(): ?string
     {
         return $this->hash;
     }
 
-    public function read($length)
+    public function read($length): string
     {
         $read = $this->stream->read($length);
         if (strlen($read) > 0) {
@@ -81,7 +73,7 @@ class HashingStream implements StreamInterface
         return $read;
     }
 
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek($offset, $whence = SEEK_SET): void
     {
         if ($offset === 0 && $whence === SEEK_SET) {
             $this->stream->seek($offset, $whence);
@@ -92,7 +84,7 @@ class HashingStream implements StreamInterface
         }
     }
 
-    private function initializeHash()
+    private function initializeHash(): void
     {
         $this->hash = null;
         $this->hashResource = hash_init(

--- a/src/HexDecodingStream.php
+++ b/src/HexDecodingStream.php
@@ -23,7 +23,7 @@ class HexDecodingStream implements StreamInterface
         $this->stream = $stream;
     }
 
-    public function getSize()
+    public function getSize(): ?int
     {
         $unencodedSize = $this->stream->getSize();
         return $unencodedSize === null
@@ -31,7 +31,7 @@ class HexDecodingStream implements StreamInterface
             : intval($unencodedSize / 2);
     }
 
-    public function read($length)
+    public function read($length): string
     {
         $this->buffer .= hex2bin($this->stream->read($length * 2));
 

--- a/src/HexEncodingStream.php
+++ b/src/HexEncodingStream.php
@@ -23,7 +23,7 @@ class HexEncodingStream implements StreamInterface
         $this->stream = $stream;
     }
 
-    public function getSize()
+    public function getSize(): ?int
     {
         $unencodedSize = $this->stream->getSize();
         return $unencodedSize === null
@@ -31,7 +31,7 @@ class HexEncodingStream implements StreamInterface
             : $unencodedSize * 2;
     }
 
-    public function read($length)
+    public function read($length): string
     {
         $this->buffer .= bin2hex($this->stream->read(ceil($length / 2)));
 

--- a/tests/AesEncryptionStreamTestTrait.php
+++ b/tests/AesEncryptionStreamTestTrait.php
@@ -21,6 +21,24 @@ trait AesEncryptionStreamTestTrait
         return $toReturn;
     }
 
+    public function cartesianJoinInputKeySizeProvider()
+    {
+        $toReturn = [];
+        $plainTexts = $this->unwrapProvider([$this, 'plainTextProvider']);
+        $keySizes = $this->unwrapProvider([$this, 'keySizeProvider']);
+
+        for ($i = 0; $i < count($plainTexts); $i++) {
+            for ($j = 0; $j < count($keySizes); $j++) {
+                $toReturn []= [
+                    $plainTexts[$i],
+                    $keySizes[$j],
+                ];
+            }
+        }
+
+        return $toReturn;
+    }
+
     public function cipherMethodProvider()
     {
         $toReturn = [];

--- a/tests/AesGcmDecryptingStreamTest.php
+++ b/tests/AesGcmDecryptingStreamTest.php
@@ -1,0 +1,63 @@
+<?php
+namespace Jsq\EncryptionStreams;
+
+use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\StreamInterface;
+
+class AesGcmDecryptingStreamTest extends TestCase
+{
+    use AesEncryptionStreamTestTrait;
+
+    /**
+     * @dataProvider cartesianJoinInputKeySizeProvider
+     *
+     * @param StreamInterface $plainText
+     * @param int $keySize
+     */
+    public function testStreamOutputSameAsOpenSSL(
+        StreamInterface $plainText,
+        $keySize
+    ) {
+        $plainText->rewind();
+        $plainText = (string) $plainText;
+        $key = 'foo';
+        $iv = random_bytes(openssl_cipher_iv_length('aes-256-gcm'));
+        $additionalData = json_encode(['foo' => 'bar']);
+        $tag = null;
+        $cipherText = openssl_encrypt(
+            $plainText,
+            "aes-{$keySize}-gcm",
+            $key,
+            OPENSSL_RAW_DATA,
+            $iv,
+            $tag,
+            $additionalData,
+            16
+        );
+
+        $decryptingStream = new AesGcmDecryptingStream(
+            Psr7\stream_for($cipherText),
+            $key,
+            $iv,
+            $tag,
+            $additionalData,
+            16,
+            $keySize
+        );
+
+        $this->assertSame((string) $decryptingStream, $plainText);
+    }
+
+    public function testIsNotWritable()
+    {
+        $decryptingStream = new AesGcmDecryptingStream(
+            Psr7\stream_for(''),
+            'key',
+            random_bytes(openssl_cipher_iv_length('aes-256-gcm')),
+            'tag'
+        );
+
+        $this->assertFalse($decryptingStream->isWritable());
+    }
+}

--- a/tests/AesGcmEncryptingStreamTest.php
+++ b/tests/AesGcmEncryptingStreamTest.php
@@ -1,0 +1,63 @@
+<?php
+namespace Jsq\EncryptionStreams;
+
+use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\StreamInterface;
+
+class AesGcmEncryptingStreamTest extends TestCase
+{
+    use AesEncryptionStreamTestTrait;
+
+    /**
+     * @dataProvider cartesianJoinInputKeySizeProvider
+     *
+     * @param StreamInterface $plainText
+     * @param int $keySize
+     */
+    public function testStreamOutputSameAsOpenSSL(
+        StreamInterface $plainText,
+        $keySize
+    ) {
+        $plainText->rewind();
+        $key = 'foo';
+        $iv = random_bytes(openssl_cipher_iv_length('aes-256-gcm'));
+        $additionalData = json_encode(['foo' => 'bar']);
+        $tag = null;
+        $encryptingStream = new AesGcmEncryptingStream(
+            $plainText,
+            $key,
+            $iv,
+            $additionalData,
+            16,
+            $keySize
+        );
+
+        $this->assertSame(
+            (string) $encryptingStream,
+            openssl_encrypt(
+                (string) $plainText,
+                "aes-{$keySize}-gcm",
+                $key,
+                OPENSSL_RAW_DATA,
+                $iv,
+                $tag,
+                $additionalData,
+                16
+            )
+        );
+
+        $this->assertSame($tag, $encryptingStream->getTag());
+    }
+
+    public function testIsNotWritable()
+    {
+        $decryptingStream = new AesGcmEncryptingStream(
+            Psr7\stream_for(''),
+            'key',
+            random_bytes(openssl_cipher_iv_length('aes-256-gcm'))
+        );
+
+        $this->assertFalse($decryptingStream->isWritable());
+    }
+}


### PR DESCRIPTION
AES-GCM is only available in PHP 7.1, so adding support for it means dropping support for 5.5, 5.6, and 7.0. Given that the provided AEAD API does not support streaming and would require the entire stream to be loaded into memory, I'm not sure this is the right direction for this library.