### PR TITLE
Add an additional read after reading a block to ensure eof is set correctly

### DIFF
--- a/src/AesDecryptingStream.php
+++ b/src/AesDecryptingStream.php
@@ -19,7 +19,7 @@ class AesDecryptingStream implements StreamInterface
     /**
      * @var string
      */
-    private $cipherBuffer;
+    private $cipherBuffer = '';
 
     /**
      * @var CipherMethod
@@ -89,6 +89,7 @@ class AesDecryptingStream implements StreamInterface
     {
         if ($offset === 0 && $whence === SEEK_SET) {
             $this->buffer = '';
+            $this->cipherBuffer = '';
             $this->cipherMethod->seek(0, SEEK_SET);
             $this->stream->seek(0, SEEK_SET);
         } else {
@@ -104,6 +105,7 @@ class AesDecryptingStream implements StreamInterface
         }
 
         $cipherText = $this->cipherBuffer;
+
         do {
             $cipherText .= $this->stream->read($length - strlen($cipherText));
         } while (strlen($cipherText) < $length && !$this->stream->eof());

--- a/src/AesDecryptingStream.php
+++ b/src/AesDecryptingStream.php
@@ -17,6 +17,11 @@ class AesDecryptingStream implements StreamInterface
     private $buffer = '';
 
     /**
+     * @var string
+     */
+    private $cipherBuffer;
+
+    /**
      * @var CipherMethod
      */
     private $cipherMethod;
@@ -98,15 +103,20 @@ class AesDecryptingStream implements StreamInterface
             return '';
         }
 
-        $cipherText = '';
+        $cipherText = $this->cipherBuffer;
         do {
             $cipherText .= $this->stream->read($length - strlen($cipherText));
         } while (strlen($cipherText) < $length && !$this->stream->eof());
 
+        // Ensure eof returns the correct value. See https://www.php.net/manual/en/function.feof.php#67261
+        $this->cipherBuffer = $this->stream->read(1);
+
+        if ($cipherText === '') {
+            return '';
+        }
+
         $options = OPENSSL_RAW_DATA;
-        if (!$this->stream->eof()
-            || $this->stream->getSize() !== $this->stream->tell()
-        ) {
+        if (!$this->stream->eof()) {
             $options |= OPENSSL_ZERO_PADDING;
         }
 


### PR DESCRIPTION
Padding is not always removed from the last block - see #10 

This MR adds an additional `read()` to ensure the `eof()` is set correctly on the stream/file. The result of the `read()` is stored in a buffer in case it's not empty and can then be used on the next read of the stream.

Fixes #9
Fixes #10