### PR TITLE
Remove stream size check when deciding whether to request padding

### DIFF
--- a/src/AesDecryptingStream.php
+++ b/src/AesDecryptingStream.php
@@ -99,9 +99,7 @@ class AesDecryptingStream implements StreamInterface
         } while (strlen($cipherText) < $length && !$this->stream->eof());
 
         $options = OPENSSL_RAW_DATA;
-        if (!$this->stream->eof()
-            || $this->stream->getSize() !== $this->stream->tell()
-        ) {
+        if (!$this->stream->eof()) {
             $options |= OPENSSL_ZERO_PADDING;
         }
 

--- a/src/AesEncryptingStream.php
+++ b/src/AesEncryptingStream.php
@@ -105,9 +105,7 @@ class AesEncryptingStream implements StreamInterface
         } while (strlen($plainText) < $length && !$this->stream->eof());
 
         $options = OPENSSL_RAW_DATA;
-        if (!$this->stream->eof()
-            || $this->stream->getSize() !== $this->stream->tell()
-        ) {
+        if (!$this->stream->eof()) {
             $options |= OPENSSL_ZERO_PADDING;
         }
 

--- a/tests/AesDecryptingStreamTest.php
+++ b/tests/AesDecryptingStreamTest.php
@@ -15,16 +15,18 @@ class AesDecryptingStreamTest extends TestCase
     /**
      * @dataProvider cartesianJoinInputCipherMethodProvider
      *
-     * @param StreamInterface $plainText
+     * @param StreamInterface $plainTextStream
+     * @param string $plainText
      * @param CipherMethod $iv
      */
     public function testStreamOutputSameAsOpenSSL(
-        StreamInterface $plainText,
+        StreamInterface $plainTextStream,
+        string $plainText,
         CipherMethod $iv
     ) {
         $key = 'foo';
         $cipherText = openssl_encrypt(
-            (string) $plainText,
+            $plainText,
             $iv->getOpenSslName(),
             $key,
             OPENSSL_RAW_DATA,
@@ -33,23 +35,25 @@ class AesDecryptingStreamTest extends TestCase
 
         $this->assertSame(
             (string) new AesDecryptingStream(Psr7\stream_for($cipherText), $key, $iv),
-            (string) $plainText
+            $plainText
         );
     }
 
     /**
      * @dataProvider cartesianJoinInputCipherMethodProvider
      *
-     * @param StreamInterface $plainText
+     * @param StreamInterface $plainTextStream
+     * @param string $plainText
      * @param CipherMethod $iv
      */
     public function testReportsSizeOfPlaintextWherePossible(
-        StreamInterface $plainText,
+        StreamInterface $plainTextStream,
+        string $plainText,
         CipherMethod $iv
     ) {
         $key = 'foo';
         $cipherText = openssl_encrypt(
-            (string) $plainText,
+            $plainText,
             $iv->getOpenSslName(),
             $key,
             OPENSSL_RAW_DATA,
@@ -64,23 +68,25 @@ class AesDecryptingStreamTest extends TestCase
         if ($iv->requiresPadding()) {
             $this->assertNull($deciphered->getSize());
         } else {
-            $this->assertSame($plainText->getSize(), $deciphered->getSize());
+            $this->assertSame(strlen($plainText), $deciphered->getSize());
         }
     }
 
     /**
      * @dataProvider cartesianJoinInputCipherMethodProvider
      *
-     * @param StreamInterface $plainText
+     * @param StreamInterface $plainTextStream
+     * @param string $plainText
      * @param CipherMethod $iv
      */
     public function testSupportsRewinding(
-        StreamInterface $plainText,
+        StreamInterface $plainTextStream,
+        string $plainText,
         CipherMethod $iv
     ) {
         $key = 'foo';
         $cipherText = openssl_encrypt(
-            (string) $plainText,
+            $plainText,
             $iv->getOpenSslName(),
             $key,
             OPENSSL_RAW_DATA,

--- a/tests/AesDecryptingStreamTest.php
+++ b/tests/AesDecryptingStreamTest.php
@@ -79,6 +79,31 @@ class AesDecryptingStreamTest extends TestCase
      * @param string $plainText
      * @param CipherMethod $iv
      */
+    public function testSupportsReadingBeyondTheEndOfTheStream(
+        StreamInterface $plainTextStream,
+        string $plainText,
+        CipherMethod $iv
+    ) {
+        $key = 'foo';
+        $cipherText = openssl_encrypt(
+            $plainText,
+            $iv->getOpenSslName(),
+            $key,
+            OPENSSL_RAW_DATA,
+            $iv->getCurrentIv()
+        );
+        $deciphered = new AesDecryptingStream(Psr7\stream_for($cipherText), $key, $iv);
+        $read = $deciphered->read(strlen($plainText) + AesDecryptingStream::BLOCK_SIZE);
+        $this->assertSame($plainText, $read);
+    }
+
+    /**
+     * @dataProvider cartesianJoinInputCipherMethodProvider
+     *
+     * @param StreamInterface $plainTextStream
+     * @param string $plainText
+     * @param CipherMethod $iv
+     */
     public function testSupportsRewinding(
         StreamInterface $plainTextStream,
         string $plainText,

--- a/tests/AesEncryptingStreamTest.php
+++ b/tests/AesEncryptingStreamTest.php
@@ -39,7 +39,7 @@ class AesEncryptingStreamTest extends TestCase
                 $plainTextStream,
                 $key,
                 $iv
-            ),
+            )
         );
     }
 

--- a/tests/AesEncryptingStreamTest.php
+++ b/tests/AesEncryptingStreamTest.php
@@ -50,6 +50,31 @@ class AesEncryptingStreamTest extends TestCase
      * @param string $plainText
      * @param CipherMethod $iv
      */
+    public function testSupportsReadingBeyondTheEndOfTheStream(
+        StreamInterface $plainTextStream,
+        string $plainText,
+        CipherMethod $iv
+    ) {
+        $key = 'foo';
+        $cipherText = openssl_encrypt(
+            $plainText,
+            $iv->getOpenSslName(),
+            $key,
+            OPENSSL_RAW_DATA,
+            $iv->getCurrentIv()
+        );
+        $cipherStream = new AesEncryptingStream($plainTextStream, $key, $iv);
+        $this->assertSame($cipherText, $cipherStream->read(strlen($plainText) + self::MB));
+        $this->assertSame('', $cipherStream->read(self::MB));
+    }
+
+    /**
+     * @dataProvider cartesianJoinInputCipherMethodProvider
+     *
+     * @param StreamInterface $plainTextStream
+     * @param string $plainText
+     * @param CipherMethod $iv
+     */
     public function testSupportsRewinding(
         StreamInterface $plainTextStream,
         string $plainText,

--- a/tests/AesEncryptingStreamTest.php
+++ b/tests/AesEncryptingStreamTest.php
@@ -78,7 +78,7 @@ class AesEncryptingStreamTest extends TestCase
         CipherMethod $iv
     ) {
         if ($plainTextStream->getSize() === null) {
-            $this->markTestSkipped('Cannot read text of ciphertext stream when plaintext stream size is unknown');
+            $this->markTestSkipped('Cannot read size of ciphertext stream when plaintext stream size is unknown');
         } else {
             $cipherText = new AesEncryptingStream($plainTextStream, 'foo', $iv);
             $this->assertSame($cipherText->getSize(), strlen((string) $cipherText));

--- a/tests/AesEncryptionStreamTestTrait.php
+++ b/tests/AesEncryptionStreamTestTrait.php
@@ -61,16 +61,16 @@ trait AesEncryptionStreamTestTrait
     public function cipherMethodProvider()
     {
         $toReturn = [];
-        foreach ($this->keySizeProvider() as $keySize) {
+        foreach ($this->unwrapProvider([$this, 'keySizeProvider']) as $keySize) {
             $toReturn []= [new Cbc(
                 random_bytes(openssl_cipher_iv_length('aes-256-cbc')),
-                $keySize[0]
+                $keySize
             )];
             $toReturn []= [new Ctr(
                 random_bytes(openssl_cipher_iv_length('aes-256-ctr')),
-                $keySize[0]
+                $keySize
             )];
-            $toReturn []= [new Ecb($keySize[0])];
+            $toReturn []= [new Ecb($keySize)];
         }
 
         return $toReturn;

--- a/tests/AesEncryptionStreamTestTrait.php
+++ b/tests/AesEncryptionStreamTestTrait.php
@@ -97,6 +97,7 @@ trait AesEncryptionStreamTestTrait
             ['The rain in Spain falls mainly on the plain.'],
             ['دست‌نوشته‌ها نمی‌سوزند'],
             ['Рукописи не горят'],
+            ['test'],
             [random_bytes(AesEncryptingStream::BLOCK_SIZE)],
             [random_bytes(2 * 1024 * 1024)],
             [random_bytes(2 * 1024 * 1024 + 11)],

--- a/tests/AesGcmDecryptingStreamTest.php
+++ b/tests/AesGcmDecryptingStreamTest.php
@@ -12,15 +12,11 @@ class AesGcmDecryptingStreamTest extends TestCase
     /**
      * @dataProvider cartesianJoinInputKeySizeProvider
      *
-     * @param StreamInterface $plainText
+     * @param StreamInterface $plainTextStream
+     * @param string $plainText
      * @param int $keySize
      */
-    public function testStreamOutputSameAsOpenSSL(
-        StreamInterface $plainText,
-        $keySize
-    ) {
-        $plainText->rewind();
-        $plainText = (string) $plainText;
+    public function testStreamOutputSameAsOpenSSL(StreamInterface $plainTextStream, string $plainText, $keySize) {
         $key = 'foo';
         $iv = random_bytes(openssl_cipher_iv_length('aes-256-gcm'));
         $additionalData = json_encode(['foo' => 'bar']);

--- a/tests/AesGcmEncryptingStreamTest.php
+++ b/tests/AesGcmEncryptingStreamTest.php
@@ -12,20 +12,17 @@ class AesGcmEncryptingStreamTest extends TestCase
     /**
      * @dataProvider cartesianJoinInputKeySizeProvider
      *
-     * @param StreamInterface $plainText
+     * @param StreamInterface $plainTextStream
+     * @param string $plainText
      * @param int $keySize
      */
-    public function testStreamOutputSameAsOpenSSL(
-        StreamInterface $plainText,
-        $keySize
-    ) {
-        $plainText->rewind();
+    public function testStreamOutputSameAsOpenSSL(StreamInterface $plainTextStream, string $plainText, $keySize) {
         $key = 'foo';
         $iv = random_bytes(openssl_cipher_iv_length('aes-256-gcm'));
         $additionalData = json_encode(['foo' => 'bar']);
         $tag = null;
         $encryptingStream = new AesGcmEncryptingStream(
-            $plainText,
+            $plainTextStream,
             $key,
             $iv,
             $additionalData,
@@ -36,7 +33,7 @@ class AesGcmEncryptingStreamTest extends TestCase
         $this->assertSame(
             (string) $encryptingStream,
             openssl_encrypt(
-                (string) $plainText,
+                $plainText,
                 "aes-{$keySize}-gcm",
                 $key,
                 OPENSSL_RAW_DATA,

--- a/tests/RandomByteStream.php
+++ b/tests/RandomByteStream.php
@@ -28,7 +28,7 @@ class RandomByteStream implements StreamInterface
         $this->stream = new PumpStream(function ($length) use (&$maxLength) {
             $length = min($length, $maxLength);
             $maxLength -= $length;
-            return openssl_random_pseudo_bytes($length);
+            return $length > 0 ? random_bytes($length) : false;
         });
     }
 


### PR DESCRIPTION
Addresses #9. This PR removes both a check in `AesEncryptingStream` of whether the underlying plaintext stream is at the final position and a corresponding check on the underlying ciphertext stream in `AesDecryptingStream`. This check was originally put in place because `$stream->eof()` will return `false` until a reader has requested data past the end of `$stream`, so streams whose length is evenly divisible by the AES block size would always send an extra empty block through the decryption/encryption method. Upon further testing, though, it seems like the extra block is necessary to get padding correct.