### PR TITLE
Throw an exception on (d)e(n)cryption failure

### DIFF
--- a/src/AesDecryptingStream.php
+++ b/src/AesDecryptingStream.php
@@ -111,7 +111,7 @@ class AesDecryptingStream implements StreamInterface
 
         $options = OPENSSL_RAW_DATA;
         $this->cipherBuffer = $this->stream->read(self::BLOCK_SIZE);
-        if ($this->cipherBuffer !== '' && !$this->stream->eof()) {
+        if (!($this->cipherBuffer === '' && $this->stream->eof())) {
             $options |= OPENSSL_ZERO_PADDING;
         }
 

--- a/src/AesDecryptingStream.php
+++ b/src/AesDecryptingStream.php
@@ -123,6 +123,12 @@ class AesDecryptingStream implements StreamInterface
             $this->cipherMethod->getCurrentIv()
         );
 
+        if ($plaintext === false) {
+            throw new DecryptionFailedException("Unable to decrypt $cipherText with an initialization vector"
+                . " of {$this->cipherMethod->getCurrentIv()} using the {$this->cipherMethod->getOpenSslName()}"
+                . " algorithm. Please ensure you have provided the correct algorithm, initialization vector, and key.");
+        }
+
         $this->cipherMethod->update($cipherText);
 
         return $plaintext;

--- a/src/AesEncryptingStream.php
+++ b/src/AesEncryptingStream.php
@@ -117,6 +117,12 @@ class AesEncryptingStream implements StreamInterface
             $this->cipherMethod->getCurrentIv()
         );
 
+        if ($cipherText === false) {
+            throw new EncryptionFailedException("Unable to encrypt data with an initialization vector"
+                . " of {$this->cipherMethod->getCurrentIv()} using the {$this->cipherMethod->getOpenSslName()}"
+                . " algorithm. Please ensure you have provided a valid algorithm and initialization vector.");
+        }
+
         $this->cipherMethod->update($cipherText);
 
         return $cipherText;

--- a/src/AesGcmDecryptingStream.php
+++ b/src/AesGcmDecryptingStream.php
@@ -43,7 +43,7 @@ class AesGcmDecryptingStream implements StreamInterface
 
     public function createStream(): StreamInterface
     {
-        return Psr7\stream_for(openssl_decrypt(
+        $plaintext = openssl_decrypt(
             (string) $this->cipherText,
             "aes-{$this->keySize}-gcm",
             $this->key,
@@ -51,7 +51,15 @@ class AesGcmDecryptingStream implements StreamInterface
             $this->initializationVector,
             $this->tag,
             $this->aad
-        ));
+        );
+
+        if ($plaintext === false) {
+            throw new DecryptionFailedException("Unable to decrypt data with an initialization vector"
+                . " of {$this->initializationVector} using the aes-{$this->keySize}-gcm algorithm. Please"
+                . " ensure you have provided a valid key size, initialization vector, and key.");
+        }
+
+        return Psr7\stream_for($plaintext);
     }
 
     public function isWritable(): bool

--- a/src/AesGcmEncryptingStream.php
+++ b/src/AesGcmEncryptingStream.php
@@ -41,7 +41,7 @@ class AesGcmEncryptingStream implements StreamInterface
 
     public function createStream(): StreamInterface
     {
-        return Psr7\stream_for(openssl_encrypt(
+        $cipherText = openssl_encrypt(
             (string) $this->plaintext,
             "aes-{$this->keySize}-gcm",
             $this->key,
@@ -50,7 +50,15 @@ class AesGcmEncryptingStream implements StreamInterface
             $this->tag,
             $this->aad,
             $this->tagLength
-        ));
+        );
+
+        if ($cipherText === false) {
+            throw new EncryptionFailedException("Unable to encrypt data with an initialization vector"
+                . " of {$this->initializationVector} using the aes-{$this->keySize}-gcm algorithm. Please"
+                . " ensure you have provided a valid key size and initialization vector.");
+        }
+
+        return Psr7\stream_for($cipherText);
     }
 
     public function getTag(): string

--- a/src/DecryptionFailedException.php
+++ b/src/DecryptionFailedException.php
@@ -1,0 +1,4 @@
+<?php
+namespace Jsq\EncryptionStreams;
+
+class DecryptionFailedException extends \RuntimeException {}

--- a/src/EncryptionFailedException.php
+++ b/src/EncryptionFailedException.php
@@ -1,0 +1,4 @@
+<?php
+namespace Jsq\EncryptionStreams;
+
+class EncryptionFailedException extends \RuntimeException {}


### PR DESCRIPTION
The current implementation does not take account of when `openssl_` functions fail and return `false` (as pointed out by @jackbentley in review of #13). This PR updates `AesDecryptingStream` and `AesEncryptingStream` to surface these errors as `DecryptionFailedException`s and `EncryptionFailedException`s, respectively. Guzzle will convert these exceptions to user errors when converting the streams to strings.