### PR TITLE
Make eof() consider padding when reading less than block size

### DIFF
--- a/src/AesEncryptingStream.php
+++ b/src/AesEncryptingStream.php
@@ -69,7 +69,11 @@ class AesEncryptingStream implements StreamInterface
         }
 
         $data = substr($this->buffer, 0, $length);
-        $this->buffer = substr($this->buffer, $length);
+        if ($length < strlen($this->buffer)) {
+            $this->buffer = substr($this->buffer, $length);
+        } else {
+            $this->buffer = '';
+        }
 
         return $data ? $data : '';
     }

--- a/src/AesEncryptingStream.php
+++ b/src/AesEncryptingStream.php
@@ -97,6 +97,11 @@ class AesEncryptingStream implements StreamInterface
         }
     }
 
+    public function eof(): bool
+    {
+        return $this->stream->eof() && $this->buffer === '';
+    }
+
     private function encryptBlock(int $length): string
     {
         if ($this->stream->eof()) {

--- a/tests/AesEncryptingStreamTest.php
+++ b/tests/AesEncryptingStreamTest.php
@@ -216,4 +216,24 @@ class AesEncryptingStreamTest extends TestCase
 
         $this->assertRegExp("/EncryptionFailedException: Unable to encrypt/", $error);
     }
+
+    /**
+     * @dataProvider cipherMethodProvider
+     *
+     * @param CipherMethod $cipherMethod
+     */
+    public function testEofShouldConsiderPaddingWhenReadSizeIsLessThenBlockSize(CipherMethod $cipherMethod)
+    {
+        $stream = new AesEncryptingStream(
+            new RandomByteStream(100),
+            self::KEY,
+            $cipherMethod
+        );
+        $expectedSize = $stream->getSize();
+        $actualSize = 0;
+        while (!$stream->eof()) {
+            $actualSize += strlen($stream->read(15));
+        }
+        $this->assertSame($expectedSize, $actualSize);
+    }
 }


### PR DESCRIPTION
When reading from AES encrypting stream with chunk length < block size `eof()` returns `true` too early leaving a part of padding in the buffer.