### PR TITLE
Fix warning and empty hash

### DIFF
--- a/src/HashingStream.php
+++ b/src/HashingStream.php
@@ -64,9 +64,11 @@ class HashingStream implements StreamInterface
             hash_update($this->hashResource, $read);
         }
         if ($this->stream->eof()) {
-            $this->hash = hash_final($this->hashResource, true);
-            if ($this->onComplete) {
-                call_user_func($this->onComplete, $this->hash);
+            if (!$this->hash) {
+                $this->hash = hash_final($this->hashResource, true);
+                if ($this->onComplete) {
+                    call_user_func($this->onComplete, $this->hash);
+                }
             }
         }
 


### PR DESCRIPTION
Sometimes stream is read even after reaching eof.
In this case hash_final is called on obsolete hashResource producing warning and destroys hash result.
Checking that hash is null prevents this behavior.
User still can seek(0) and set hash to null in initializeHash function.

Use case:
AesDecryptingStream:113 calls read on empty stream (in our case its HashingStream) in order to prefetch data.
Results:
* Warning is produced.
* Hash is spoiled.