### PR TITLE
fix for AesStream->read(length=1)

### DIFF
--- a/src/AesDecryptingStream.php
+++ b/src/AesDecryptingStream.php
@@ -79,10 +79,9 @@ class AesDecryptingStream implements StreamInterface
             );
         }
 
-        $data = substr($this->plainBuffer, 0, $length);
-        $this->plainBuffer = substr($this->plainBuffer, $length);
-
-        return $data ? $data : '';
+        $data = (string)substr($this->plainBuffer, 0, $length);
+        $this->plainBuffer = (string)substr($this->plainBuffer, $length);
+        return $data;
     }
 
     public function seek($offset, $whence = SEEK_SET): void

--- a/src/AesEncryptingStream.php
+++ b/src/AesEncryptingStream.php
@@ -68,10 +68,9 @@ class AesEncryptingStream implements StreamInterface
             );
         }
 
-        $data = substr($this->buffer, 0, $length);
-        $this->buffer = substr($this->buffer, $length);
-
-        return $data ? $data : '';
+        $data = (string)substr($this->buffer, 0, $length);
+        $this->buffer = (string)substr($this->buffer, $length);
+        return $data;
     }
 
     public function seek($offset, $whence = SEEK_SET): void

--- a/tests/AesDecryptingStreamTest.php
+++ b/tests/AesDecryptingStreamTest.php
@@ -198,4 +198,24 @@ class AesDecryptingStreamTest extends TestCase
 
         $this->assertRegExp("/DecryptionFailedException: Unable to decrypt/", $error);
     }
+
+    /**
+     * @dataProvider cipherMethodProvider
+     *
+     * @param CipherMethod $iv
+     */
+    public function testSupportsReadLength1(
+        CipherMethod $iv
+    ) {
+        $plain = str_repeat("0", 100);
+        $cipherStream = new AesEncryptingStream(Psr7\stream_for($plain), self::KEY, clone $iv);
+        $stream = new AesDecryptingStream($cipherStream, self::KEY, clone $iv);
+
+        $result = "";
+        for ($i = 0; $i < 100; $i++) {
+            $result .= $stream->read(1);
+        }
+
+        $this->assertEquals($plain, $result);
+    }
 }

--- a/tests/AesEncryptingStreamTest.php
+++ b/tests/AesEncryptingStreamTest.php
@@ -216,4 +216,21 @@ class AesEncryptingStreamTest extends TestCase
 
         $this->assertRegExp("/EncryptionFailedException: Unable to encrypt/", $error);
     }
+
+    public function testSupportsReadLength1()
+    {
+        $key = "keyy";
+        $plain = str_repeat("a", 49);
+        $iv = hex2bin("5dfe91624ede1efc6bc1c90e1932c398");
+
+        $cipherMethod = new Cbc($iv, $keySize=128);
+        $e = new AesEncryptingStream(Psr7\stream_for($plain), $key, $cipherMethod);
+
+        $result = "";
+        for ($i = 0; $i < 100; $i++) {
+            $result .= $e->read(1);
+        }
+
+        $this->assertEquals(64, strlen($result));
+    }
 }


### PR DESCRIPTION
When reading from an Aes*cryptionStream with ```read($length=1)``` and ```$data === "0"```, then ```return $data ? $data : '';``` just gives an empty string.