### PR TITLE
Upgrade to PHP 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 composer.phar
 /vendor/
 composer.lock
-
 coverage-report/
-
+.phpunit.result.cache
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 7.1
-  - 7.2
-  - 7.3
+  - 8.1
+  - 8.2
+  - 8.3
 
 env:
   - COMPOSER_OPTS=""

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $key = 'some-secret-password-here';
 
 $inStream = new Stream(fopen('some-input-file', 'r')); // Any PSR-7 stream will be fine here
 $cipherTextStream = new AesEncryptingStream($inStream, $key, $cipherMethod); // Wrap the stream in an EncryptingStream
-$cipherTextFile = Psr7\stream_for(fopen('encrypted.file', 'w'));
+$cipherTextFile = Psr7\Utils::streamFor(fopen('encrypted.file', 'w'));
 Psr7\copy_to_stream($cipherTextStream, $cipherTextFile); // When you read from the encrypting stream, the data will be encrypted.
 
 // You'll also need to store the IV somewhere, because we'll need it later to decrypt the data.
@@ -83,7 +83,7 @@ $cipherText = openssl_encrypt(
 $expectedHash = hash('sha256', $cipherText);
 
 $hashingDecorator = new Jsq\EncryptingStreams\HashingStream(
-    GuzzleHttp\Psr7\stream_for($cipherText),
+    GuzzleHttp\Psr7\Utils::streamFor($cipherText),
     $key,
     function ($hash) use ($expectedHash) {
         if ($hash !== $expectedHash) {

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,15 @@
     }
   },
   "require": {
-    "php": ">=7.1",
+    "php": ">=8.1",
     "ext-openssl": "*",
-    "guzzlehttp/psr7": "~1.0",
-    "psr/http-message": "~1.0"
+    "guzzlehttp/psr7": "~2.6",
+    "psr/http-message": "~2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^6.0"
+    "phpunit/phpunit": "^10.0"
+  },
+  "scripts": {
+    "tests": "phpunit"
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/autoload.php"
-         colors="true">
-
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" colors="true"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
     <testsuites>
         <testsuite name="unit">
             <directory suffix="Test.php">tests/</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
+    <source>
+        <include>
             <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-
+        </include>
+    </source>
 </phpunit>

--- a/src/Base64DecodingStream.php
+++ b/src/Base64DecodingStream.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Jsq\EncryptionStreams;
 
 use GuzzleHttp\Psr7\StreamDecoratorTrait;
@@ -8,19 +9,10 @@ class Base64DecodingStream implements StreamInterface
 {
     use StreamDecoratorTrait;
 
-    /**
-     * @var string
-     */
-    private $buffer = '';
+    private string $buffer = '';
 
-    /**
-     * @var StreamInterface
-     */
-    private $stream;
-
-    public function __construct(StreamInterface $stream)
+    public function __construct(private readonly StreamInterface $stream)
     {
-        $this->stream = $stream;
     }
 
     public function getSize(): ?int
@@ -28,9 +20,9 @@ class Base64DecodingStream implements StreamInterface
         return null;
     }
 
-    public function read($length): string
+    public function read(int $length): string
     {
-        $toRead = ceil($length / 3) * 4;
+        $toRead = (int)ceil($length / 3) * 4;
         $this->buffer .= base64_decode($this->stream->read($toRead));
 
         $toReturn = substr($this->buffer, 0, $length);

--- a/src/Base64EncodingStream.php
+++ b/src/Base64EncodingStream.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Jsq\EncryptionStreams;
 
 use GuzzleHttp\Psr7\StreamDecoratorTrait;
@@ -8,19 +9,10 @@ class Base64EncodingStream implements StreamInterface
 {
     use StreamDecoratorTrait;
 
-    /**
-     * @var string
-     */
-    private $buffer = '';
+    private string $buffer = '';
 
-    /**
-     * @var StreamInterface
-     */
-    private $stream;
-
-    public function __construct(StreamInterface $stream)
+    public function __construct(private readonly StreamInterface $stream)
     {
-        $this->stream = $stream;
     }
 
     public function getSize(): ?int
@@ -28,12 +20,12 @@ class Base64EncodingStream implements StreamInterface
         $unencodedSize = $this->stream->getSize();
         return $unencodedSize === null
             ? null
-            : (int) ceil($unencodedSize / 3) * 4;
+            : (int)ceil($unencodedSize / 3) * 4;
     }
 
     public function read($length): string
     {
-        $toRead = ceil($length / 4) * 3;
+        $toRead = (int)ceil($length / 4) * 3;
         $this->buffer .= base64_encode($this->stream->read($toRead));
 
         $toReturn = substr($this->buffer, 0, $length);

--- a/src/Cbc.php
+++ b/src/Cbc.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Jsq\EncryptionStreams;
 
 use InvalidArgumentException as Iae;
@@ -6,36 +7,21 @@ use LogicException;
 
 class Cbc implements CipherMethod
 {
-    const BLOCK_SIZE = 16;
+    public const BLOCK_SIZE = 16;
 
-    /**
-     * @var string
-     */
-    private $baseIv;
+    private ?string $iv;
 
-    /**
-     * @var string
-     */
-    private $iv;
-
-    /**
-     * @var int
-     */
-    private $keySize;
-
-    public function __construct(string $iv, int $keySize = 256)
+    public function __construct(private readonly string $baseIv, private readonly int $keySize = 256)
     {
-        $this->baseIv = $this->iv = $iv;
-        $this->keySize = $keySize;
-
-        if (strlen($iv) !== openssl_cipher_iv_length($this->getOpenSslName())) {
+        $this->iv = $this->baseIv;
+        if (strlen($this->baseIv) !== openssl_cipher_iv_length($this->getOpenSslName())) {
             throw new Iae('Invalid initialization vector');
         }
     }
 
     public function getOpenSslName(): string
     {
-        return "aes-{$this->keySize}-cbc";
+        return sprintf('aes-%d-cbc', $this->keySize);
     }
 
     public function getCurrentIv(): string
@@ -53,8 +39,7 @@ class Cbc implements CipherMethod
         if ($offset === 0 && $whence === SEEK_SET) {
             $this->iv = $this->baseIv;
         } else {
-            throw new LogicException('CBC initialization only support being'
-                . ' rewound, not arbitrary seeking.');
+            throw new LogicException('CBC initialization only support being rewound, not arbitrary seeking.');
         }
     }
 

--- a/src/CipherMethod.php
+++ b/src/CipherMethod.php
@@ -8,8 +8,6 @@ interface CipherMethod
     /**
      * Returns an identifier recognizable by `openssl_*` functions, such as
      * `aes-256-cbc` or `aes-128-ctr`.
-     *
-     * @return string
      */
     public function getOpenSslName(): string;
 
@@ -29,8 +27,6 @@ interface CipherMethod
      * Adjust the return of this::getCurrentIv to reflect a seek performed on
      * the encryption stream using this IV object.
      *
-     * @param int $offset
-     * @param int $whence
      *
      * @throws LogicException   Thrown if the requested seek is not supported by
      *                          this IV implementation. For example, a CBC IV
@@ -42,8 +38,6 @@ interface CipherMethod
     /**
      * Take account of the last cipher text block to adjust the return of
      * this::getCurrentIv
-     *
-     * @param string $cipherTextBlock
      */
     public function update(string $cipherTextBlock): void;
 }

--- a/src/DecryptionFailedException.php
+++ b/src/DecryptionFailedException.php
@@ -1,4 +1,6 @@
 <?php
 namespace Jsq\EncryptionStreams;
 
-class DecryptionFailedException extends \RuntimeException {}
+use RuntimeException;
+
+class DecryptionFailedException extends RuntimeException {}

--- a/src/Ecb.php
+++ b/src/Ecb.php
@@ -3,22 +3,13 @@ namespace Jsq\EncryptionStreams;
 
 class Ecb implements CipherMethod
 {
-    /**
-     * @var int
-     */
-    private $keySize;
-
-    /**
-     * @param int $keySize
-     */
-    public function __construct(int $keySize = 256)
+    public function __construct(private readonly int $keySize = 256)
     {
-        $this->keySize = $keySize;
     }
 
     public function getOpenSslName(): string
     {
-        return "aes-{$this->keySize}-ecb";
+        return sprintf('aes-%d-ecb', $this->keySize);
     }
 
     public function getCurrentIv(): string

--- a/src/EncryptionFailedException.php
+++ b/src/EncryptionFailedException.php
@@ -1,4 +1,6 @@
 <?php
 namespace Jsq\EncryptionStreams;
 
-class EncryptionFailedException extends \RuntimeException {}
+use RuntimeException;
+
+class EncryptionFailedException extends RuntimeException {}

--- a/src/HexDecodingStream.php
+++ b/src/HexDecodingStream.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Jsq\EncryptionStreams;
 
 use GuzzleHttp\Psr7\StreamDecoratorTrait;
@@ -8,19 +9,10 @@ class HexDecodingStream implements StreamInterface
 {
     use StreamDecoratorTrait;
 
-    /**
-     * @var string
-     */
-    private $buffer = '';
+    private string $buffer = '';
 
-    /**
-     * @var StreamInterface
-     */
-    private $stream;
-
-    public function __construct(StreamInterface $stream)
+    public function __construct(private readonly StreamInterface $stream)
     {
-        $this->stream = $stream;
     }
 
     public function getSize(): ?int

--- a/src/HexEncodingStream.php
+++ b/src/HexEncodingStream.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Jsq\EncryptionStreams;
 
 use GuzzleHttp\Psr7\StreamDecoratorTrait;
@@ -8,19 +9,10 @@ class HexEncodingStream implements StreamInterface
 {
     use StreamDecoratorTrait;
 
-    /**
-     * @var string
-     */
-    private $buffer = '';
+    private string $buffer = '';
 
-    /**
-     * @var StreamInterface
-     */
-    private $stream;
-
-    public function __construct(StreamInterface $stream)
+    public function __construct(private readonly StreamInterface $stream)
     {
-        $this->stream = $stream;
     }
 
     public function getSize(): ?int
@@ -33,7 +25,7 @@ class HexEncodingStream implements StreamInterface
 
     public function read($length): string
     {
-        $this->buffer .= bin2hex($this->stream->read(ceil($length / 2)));
+        $this->buffer .= bin2hex($this->stream->read((int)ceil($length / 2)));
 
         $toReturn = substr($this->buffer, 0, $length);
         $this->buffer = substr($this->buffer, $length);

--- a/tests/Base64DecodingStreamTest.php
+++ b/tests/Base64DecodingStreamTest.php
@@ -1,31 +1,31 @@
 <?php
 namespace Jsq\EncryptionStreams;
 
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
 
 class Base64DecodingStreamTest extends TestCase
 {
-    const MB = 1048576;
+    public const MB = 1048576;
 
-    public function testEncodingShouldMatchBase64_DecodeOutput()
+    public function testEncodingShouldMatchBase64_DecodeOutput(): void
     {
-        $stream = Psr7\stream_for(base64_encode(random_bytes(1027)));
+        $stream = Utils::streamFor(base64_encode(random_bytes(1027)));
         $encodingStream = new Base64DecodingStream($stream);
 
         $this->assertSame(base64_decode($stream), (string) $encodingStream);
     }
 
-    public function testShouldReportNullAsSize()
+    public function testShouldReportNullAsSize(): void
     {
         $encodingStream = new Base64DecodingStream(
-            Psr7\stream_for(base64_encode(random_bytes(1027)))
+            Utils::streamFor(base64_encode(random_bytes(1027)))
         );
 
         $this->assertNull($encodingStream->getSize());
     }
 
-    public function testMemoryUsageRemainsConstant()
+    public function testMemoryUsageRemainsConstant(): void
     {
         $memory = memory_get_usage();
 

--- a/tests/Base64EncodingStreamTest.php
+++ b/tests/Base64EncodingStreamTest.php
@@ -1,41 +1,39 @@
 <?php
 namespace Jsq\EncryptionStreams;
 
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 use GuzzleHttp\Psr7\PumpStream;
 use PHPUnit\Framework\TestCase;
 
 class Base64EncodingStreamTest extends TestCase
 {
-    const MB = 1048576;
+    public const MB = 1048576;
 
-    public function testEncodingShouldMatchBase64_EncodeOutput()
+    public function testEncodingShouldMatchBase64_EncodeOutput(): void
     {
         $bytes = random_bytes(self::MB + 3);
-        $encodingStream = new Base64EncodingStream(Psr7\stream_for($bytes));
+        $encodingStream = new Base64EncodingStream(Utils::streamFor($bytes));
 
         $this->assertSame(base64_encode($bytes), (string) $encodingStream);
     }
 
-    public function testShouldReportSizeOfEncodedStream()
+    public function testShouldReportSizeOfEncodedStream(): void
     {
         $bytes = random_bytes(self::MB + 3);
-        $encodingStream = new Base64EncodingStream(Psr7\stream_for($bytes));
+        $encodingStream = new Base64EncodingStream(Utils::streamFor($bytes));
 
         $this->assertSame(strlen(base64_encode($bytes)), $encodingStream->getSize());
     }
 
-    public function testShouldReportNullIfSizeOfSourceStreamUnknown()
+    public function testShouldReportNullIfSizeOfSourceStreamUnknown(): void
     {
-        $stream = new PumpStream(function ($length) {
-            return random_bytes($length);
-        });
+        $stream = new PumpStream(fn($length): string => random_bytes($length));
         $encodingStream = new Base64EncodingStream($stream);
 
         $this->assertNull($encodingStream->getSize());
     }
 
-    public function testMemoryUsageRemainsConstant()
+    public function testMemoryUsageRemainsConstant(): void
     {
         $memory = memory_get_usage();
 

--- a/tests/CbcTest.php
+++ b/tests/CbcTest.php
@@ -1,17 +1,19 @@
 <?php
 namespace Jsq\EncryptionStreams;
 
+use InvalidArgumentException;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 
 class CbcTest extends TestCase
 {
-    public function testShouldReportCipherMethodOfCBC()
+    public function testShouldReportCipherMethodOfCBC(): void
     {
         $ivString = random_bytes(openssl_cipher_iv_length('aes-256-cbc'));
         $this->assertSame('aes-256-cbc', (new Cbc($ivString))->getOpenSslName());
     }
 
-    public function testShouldReturnInitialIvStringForCurrentIvBeforeUpdate()
+    public function testShouldReturnInitialIvStringForCurrentIvBeforeUpdate(): void
     {
         $ivString = random_bytes(openssl_cipher_iv_length('aes-256-cbc'));
         $iv = new Cbc($ivString);
@@ -19,7 +21,7 @@ class CbcTest extends TestCase
         $this->assertSame($ivString, $iv->getCurrentIv());
     }
 
-    public function testUpdateShouldSetCurrentIvToEndOfCipherBlock()
+    public function testUpdateShouldSetCurrentIvToEndOfCipherBlock(): void
     {
         $ivLength = openssl_cipher_iv_length('aes-256-cbc');
         $ivString = random_bytes($ivLength);
@@ -34,15 +36,13 @@ class CbcTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testShouldThrowWhenIvOfInvalidLengthProvided()
+    public function testShouldThrowWhenIvOfInvalidLengthProvided(): void
     {
+        $this->expectException(InvalidArgumentException::class);
         new Cbc(random_bytes(openssl_cipher_iv_length('aes-256-cbc') + 1));
     }
 
-    public function testShouldSupportSeekingToBeginning()
+    public function testShouldSupportSeekingToBeginning(): void
     {
         $ivString = random_bytes(openssl_cipher_iv_length('aes-256-cbc'));
         $iv = new Cbc($ivString);
@@ -53,11 +53,9 @@ class CbcTest extends TestCase
         $this->assertSame($ivString, $iv->getCurrentIv());
     }
 
-    /**
-     * @expectedException \LogicException
-     */
-    public function testShouldThrowWhenNonZeroOffsetProvidedToSeek()
+    public function testShouldThrowWhenNonZeroOffsetProvidedToSeek(): void
     {
+        $this->expectException(LogicException::class);
         $ivString = random_bytes(openssl_cipher_iv_length('aes-256-cbc'));
         $iv = new Cbc($ivString);
         $cipherTextBlock = random_bytes(1024);
@@ -66,11 +64,9 @@ class CbcTest extends TestCase
         $iv->seek(1);
     }
 
-    /**
-     * @expectedException \LogicException
-     */
-    public function testShouldThrowWhenSeekCurProvidedToSeek()
+    public function testShouldThrowWhenSeekCurProvidedToSeek(): void
     {
+        $this->expectException(LogicException::class);
         $ivString = random_bytes(openssl_cipher_iv_length('aes-256-cbc'));
         $iv = new Cbc($ivString);
         $cipherTextBlock = random_bytes(1024);
@@ -79,11 +75,9 @@ class CbcTest extends TestCase
         $iv->seek(0, SEEK_CUR);
     }
 
-    /**
-     * @expectedException \LogicException
-     */
-    public function testShouldThrowWhenSeekEndProvidedToSeek()
+    public function testShouldThrowWhenSeekEndProvidedToSeek(): void
     {
+        $this->expectException(LogicException::class);
         $ivString = random_bytes(openssl_cipher_iv_length('aes-256-cbc'));
         $iv = new Cbc($ivString);
         $cipherTextBlock = random_bytes(1024);

--- a/tests/CtrTest.php
+++ b/tests/CtrTest.php
@@ -1,17 +1,19 @@
 <?php
 namespace Jsq\EncryptionStreams;
 
+use InvalidArgumentException;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 
 class CtrTest extends TestCase
 {
-    public function testShouldReportCipherMethodOfCTR()
+    public function testShouldReportCipherMethodOfCTR(): void
     {
         $ivString = random_bytes(openssl_cipher_iv_length('aes-256-ctr'));
         $this->assertSame('aes-256-ctr', (new Ctr($ivString))->getOpenSslName());
     }
 
-    public function testShouldReturnInitialIvStringForCurrentIvBeforeUpdate()
+    public function testShouldReturnInitialIvStringForCurrentIvBeforeUpdate(): void
     {
         $ivString = random_bytes(openssl_cipher_iv_length('aes-256-ctr'));
         $iv = new Ctr($ivString);
@@ -19,9 +21,9 @@ class CtrTest extends TestCase
         $this->assertSame($ivString, $iv->getCurrentIv());
     }
 
-    public function testUpdateShouldSetIncrementIvByNumberOfBlocksProcessed()
+    public function testUpdateShouldSetIncrementIvByNumberOfBlocksProcessed(): void
     {
-        $ivString = $iv = hex2bin('deadbeefdeadbeefdeadbeefdeadbeee');
+        $ivString = hex2bin('deadbeefdeadbeefdeadbeefdeadbeee');
         $iv = new Ctr($ivString);
         $cipherTextBlock = random_bytes(Ctr::BLOCK_SIZE);
 
@@ -33,15 +35,13 @@ class CtrTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testShouldThrowWhenIvOfInvalidLengthProvided()
+    public function testShouldThrowWhenIvOfInvalidLengthProvided(): void
     {
+        $this->expectException(InvalidArgumentException::class);
         new Ctr(random_bytes(openssl_cipher_iv_length('aes-256-ctr') + 1));
     }
 
-    public function testShouldSupportSeekingToBeginning()
+    public function testShouldSupportSeekingToBeginning(): void
     {
         $ivString = random_bytes(openssl_cipher_iv_length('aes-256-ctr'));
         $iv = new Ctr($ivString);
@@ -52,7 +52,7 @@ class CtrTest extends TestCase
         $this->assertSame($ivString, $iv->getCurrentIv());
     }
 
-    public function testShouldSupportSeekingFromCurrentPosition()
+    public function testShouldSupportSeekingFromCurrentPosition(): void
     {
         $ivString = random_bytes(openssl_cipher_iv_length('aes-256-ctr'));
         $iv = new Ctr($ivString);
@@ -64,11 +64,9 @@ class CtrTest extends TestCase
         $this->assertNotSame($updatedIv, $iv->getCurrentIv());
     }
 
-    /**
-     * @expectedException \LogicException
-     */
-    public function testShouldThrowWhenSeekOffsetNotDivisibleByBlockSize()
+    public function testShouldThrowWhenSeekOffsetNotDivisibleByBlockSize(): void
     {
+        $this->expectException(LogicException::class);
         $ivString = random_bytes(openssl_cipher_iv_length('aes-256-ctr'));
         $iv = new Ctr($ivString);
         $cipherTextBlock = random_bytes(1024);
@@ -77,11 +75,9 @@ class CtrTest extends TestCase
         $iv->seek(1);
     }
 
-    /**
-     * @expectedException \LogicException
-     */
-    public function testShouldThrowWhenNegativeSeekCurProvidedToSeek()
+    public function testShouldThrowWhenNegativeSeekCurProvidedToSeek(): void
     {
+        $this->expectException(LogicException::class);
         $ivString = random_bytes(openssl_cipher_iv_length('aes-256-ctr'));
         $iv = new Ctr($ivString);
         $cipherTextBlock = random_bytes(1024);
@@ -90,11 +86,9 @@ class CtrTest extends TestCase
         $iv->seek(Ctr::BLOCK_SIZE * -1, SEEK_CUR);
     }
 
-    /**
-     * @expectedException \LogicException
-     */
-    public function testShouldThrowWhenSeekEndProvidedToSeek()
+    public function testShouldThrowWhenSeekEndProvidedToSeek(): void
     {
+        $this->expectException(LogicException::class);
         $ivString = random_bytes(openssl_cipher_iv_length('aes-256-ctr'));
         $iv = new Ctr($ivString);
         $cipherTextBlock = random_bytes(1024);

--- a/tests/EcbTest.php
+++ b/tests/EcbTest.php
@@ -5,12 +5,12 @@ use PHPUnit\Framework\TestCase;
 
 class EcbTest extends TestCase
 {
-    public function testShouldReportCipherMethodOfECB()
+    public function testShouldReportCipherMethodOfECB(): void
     {
         $this->assertSame('aes-256-ecb', (new Ecb)->getOpenSslName());
     }
 
-    public function testShouldReturnEmptyStringForCurrentIv()
+    public function testShouldReturnEmptyStringForCurrentIv(): void
     {
         $iv = new Ecb();
         $this->assertEmpty($iv->getCurrentIv());
@@ -18,7 +18,7 @@ class EcbTest extends TestCase
         $this->assertEmpty($iv->getCurrentIv());
     }
 
-    public function testSeekShouldBeNoOp()
+    public function testSeekShouldBeNoOp(): void
     {
         $iv = new Ecb();
         $baseIv = $iv->getCurrentIv();
@@ -26,7 +26,7 @@ class EcbTest extends TestCase
         $this->assertSame($baseIv, $iv->getCurrentIv());
     }
 
-    public function testShouldReportThatPaddingIsRequired()
+    public function testShouldReportThatPaddingIsRequired(): void
     {
         $this->assertTrue((new Ecb)->requiresPadding());
     }

--- a/tests/ExceptionAssertions.php
+++ b/tests/ExceptionAssertions.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jsq\EncryptionStreams;
+
+use Exception;
+
+trait ExceptionAssertions
+{
+    public function assertException(callable $act, Exception $exception): void
+    {
+        $this->expectExceptionObject($exception);
+        $act();
+    }
+}

--- a/tests/HexDecodingStreamTest.php
+++ b/tests/HexDecodingStreamTest.php
@@ -1,41 +1,39 @@
 <?php
 namespace Jsq\EncryptionStreams;
 
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 use GuzzleHttp\Psr7\PumpStream;
 use PHPUnit\Framework\TestCase;
 
 class HexDecodingStreamTest extends TestCase
 {
-    const MB = 1048576;
+    public const MB = 1048576;
 
-    public function testEncodingShouldMatchHex2BinOutput()
+    public function testEncodingShouldMatchHex2BinOutput(): void
     {
-        $stream = Psr7\stream_for(bin2hex(random_bytes(1027)));
+        $stream = Utils::streamFor(bin2hex(random_bytes(1027)));
         $encodingStream = new HexDecodingStream($stream);
 
         $this->assertSame(hex2bin($stream), (string) $encodingStream);
     }
 
-    public function testShouldReportSizeOfDecodedStream()
+    public function testShouldReportSizeOfDecodedStream(): void
     {
-        $stream = Psr7\stream_for(bin2hex(random_bytes(1027)));
+        $stream = Utils::streamFor(bin2hex(random_bytes(1027)));
         $encodingStream = new HexDecodingStream($stream);
 
         $this->assertSame(strlen(hex2bin($stream)), $encodingStream->getSize());
     }
 
-    public function testShouldReportNullIfSizeOfSourceStreamUnknown()
+    public function testShouldReportNullIfSizeOfSourceStreamUnknown(): void
     {
-        $stream = new PumpStream(function () {
-            return bin2hex(random_bytes(self::MB));
-        });
+        $stream = new PumpStream(fn(): string => bin2hex(random_bytes(self::MB)));
         $encodingStream = new HexDecodingStream($stream);
 
         $this->assertNull($encodingStream->getSize());
     }
 
-    public function testMemoryUsageRemainsConstant()
+    public function testMemoryUsageRemainsConstant(): void
     {
         $memory = memory_get_usage();
 

--- a/tests/HexEncodingStreamTest.php
+++ b/tests/HexEncodingStreamTest.php
@@ -1,41 +1,39 @@
 <?php
 namespace Jsq\EncryptionStreams;
 
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 use GuzzleHttp\Psr7\PumpStream;
 use PHPUnit\Framework\TestCase;
 
 class HexEncodingStreamTest extends TestCase
 {
-    const MB = 1048576;
+    public const MB = 1048576;
 
-    public function testEncodingShouldMatchBin2HexOutput()
+    public function testEncodingShouldMatchBin2HexOutput(): void
     {
         $bytes = random_bytes(self::MB + 3);
-        $encodingStream = new HexEncodingStream(Psr7\stream_for($bytes));
+        $encodingStream = new HexEncodingStream(Utils::streamFor($bytes));
 
         $this->assertSame(bin2hex($bytes), (string) $encodingStream);
     }
 
-    public function testShouldReportSizeOfEncodedStream()
+    public function testShouldReportSizeOfEncodedStream(): void
     {
         $bytes = random_bytes(self::MB + 3);
-        $encodingStream = new HexEncodingStream(Psr7\stream_for($bytes));
+        $encodingStream = new HexEncodingStream(Utils::streamFor($bytes));
 
         $this->assertSame(strlen(bin2hex($bytes)), $encodingStream->getSize());
     }
 
-    public function testShouldReportNullIfSizeOfSourceStreamUnknown()
+    public function testShouldReportNullIfSizeOfSourceStreamUnknown(): void
     {
-        $stream = new PumpStream(function ($length) {
-            return random_bytes($length);
-        });
+        $stream = new PumpStream(fn($length): string => random_bytes($length));
         $encodingStream = new HexEncodingStream($stream);
 
         $this->assertNull($encodingStream->getSize());
     }
 
-    public function testMemoryUsageRemainsConstant()
+    public function testMemoryUsageRemainsConstant(): void
     {
         $memory = memory_get_usage();
 

--- a/tests/RandomByteStream.php
+++ b/tests/RandomByteStream.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Jsq\EncryptionStreams;
 
 use GuzzleHttp\Psr7\PumpStream;
@@ -10,11 +11,6 @@ class RandomByteStream implements StreamInterface
     use StreamDecoratorTrait;
 
     /**
-     * @var int
-     */
-    private $maxLength;
-
-    /**
      * @var PumpStream
      */
     private $stream;
@@ -22,17 +18,16 @@ class RandomByteStream implements StreamInterface
     /**
      * @param int $maxLength
      */
-    public function __construct($maxLength)
+    public function __construct(private $maxLength)
     {
-        $this->maxLength = $maxLength;
-        $this->stream = new PumpStream(function ($length) use (&$maxLength) {
-            $length = min($length, $maxLength);
-            $maxLength -= $length;
+        $this->stream = new PumpStream(function ($length) {
+            $length = min($length, $this->maxLength);
+            $this->maxLength -= $length;
             return $length > 0 ? random_bytes($length) : false;
         });
     }
 
-    public function getSize()
+    public function getSize(): ?int
     {
         return $this->maxLength;
     }


### PR DESCRIPTION
I've upgraded code and dependencies to PHP 8.1+.
I decided to not care about PHP 7 as it is
unmaintained... So changes are not bc.
Although interfaces hasn't changed that much, I only added types where they were missing.

After switch to PHP 8, deprecation errors occurred because of StreamDecoratorTrait dynamic property declaration and I don't see any good solution to fix them for now. So I added #[\AllowDynamicProperties] to ignore them. They are not breaking anything and if they will in the future, there are tests covering it.